### PR TITLE
Add failure test cases for CRUD operations

### DIFF
--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1,0 +1,183 @@
+import pytest
+from fastapi import status
+from square_database_structure.square.public.enums import TestEnumEnum
+
+
+def test_insert_rows_invalid_database(create_client_and_cleanup):
+    """Test inserting rows with an invalid database name"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "invalid_db",
+            "schema_name": "public",
+            "table_name": "test",
+            "data": [{"test_text": "example"}],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INCORRECT_DATABASE_NAME" in response.json()["message"]
+
+
+def test_insert_rows_invalid_schema(create_client_and_cleanup):
+    """Test inserting rows with an invalid schema name"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "invalid_schema",
+            "table_name": "test",
+            "data": [{"test_text": "example"}],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INCORRECT_SCHEMA_NAME" in response.json()["message"]
+
+
+def test_insert_rows_invalid_table(create_client_and_cleanup):
+    """Test inserting rows with an invalid table name"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "invalid_table",
+            "data": [{"test_text": "example"}],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INCORRECT_TABLE_NAME" in response.json()["message"]
+
+
+def test_insert_rows_invalid_data(create_client_and_cleanup):
+    """Test inserting rows with invalid data structure"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "data": [{"invalid_column": "example"}],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_get_rows_invalid_filter(create_client_and_cleanup):
+    """Test getting rows with invalid filter condition"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/get_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "filters": {"invalid_column": {"eq": "value"}},
+            "apply_filters": True,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_get_rows_invalid_order_by(create_client_and_cleanup):
+    """Test getting rows with invalid order_by column"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/get_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "order_by": ["invalid_column"],
+            "filters": {},
+            "apply_filters": False,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_edit_rows_invalid_data(create_client_and_cleanup, fixture_edit_rows):
+    """Test editing rows with invalid data structure"""
+    client = create_client_and_cleanup
+    # First insert a row to edit
+    client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "data": [{"test_text": "to_edit"}],
+        },
+    )
+
+    # Try to edit with invalid data
+    response = client.patch(
+        "/edit_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "filters": {"test_text": {"eq": "to_edit"}},
+            "data": {"invalid_column": "new_value"},
+            "apply_filters": True,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_edit_rows_invalid_filter_column(create_client_and_cleanup):
+    """Test editing rows with invalid filter column"""
+    client = create_client_and_cleanup
+    response = client.patch(
+        "/edit_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "filters": {"invalid_column": {"eq": "value"}},
+            "data": {"test_text": "new_value"},
+            "apply_filters": True,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_delete_rows_invalid_filter_column(create_client_and_cleanup):
+    """Test deleting rows with invalid filter column"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/delete_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "filters": {"invalid_column": {"eq": "value"}},
+            "apply_filters": True,
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]
+
+
+def test_invalid_enum_value(create_client_and_cleanup):
+    """Test inserting an invalid enum value"""
+    client = create_client_and_cleanup
+    response = client.post(
+        "/insert_rows/v0",
+        json={
+            "database_name": "square",
+            "schema_name": "public",
+            "table_name": "test",
+            "data": [{"test_text": "example", "test_enum_enum": "INVALID_VALUE"}],
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "GENERIC_400" in response.json()["message"]


### PR DESCRIPTION
This PR adds comprehensive failure test cases for CRUD operations in the square_database project.

New test cases cover:
1. Invalid database operations:
   - Invalid database name
   - Invalid schema name
   - Invalid table name

2. Invalid data operations:
   - Invalid data structure in inserts
   - Invalid column names in filters
   - Invalid enum values

3. Filter-related failures:
   - Invalid filter columns
   - Invalid order by columns

4. Edit operation failures:
   - Invalid data structure in updates
   - Invalid filter columns

5. Delete operation failures:
   - Invalid filter columns

These tests ensure proper error handling and response codes for various failure scenarios.